### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/guaka/hitchticker.png?label=ready&title=Ready)](https://waffle.io/guaka/hitchticker)
 # Hitchticker
 
 An Open Source Message Ticker — easy to use and accessable.


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/guaka/hitchticker

This was requested by a real person (user guaka) on waffle.io, we're not trying to spam you.
